### PR TITLE
Support HotChocolate 15 (v6)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,8 @@ jobs:
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
       - name: Run tests
         run: dotnet test src/ --collect:"XPlat Code Coverage"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ We strive to match Hot Chocolate's supported .NET target frameworks, though this
 
 | HotChocolate | Polymorphic IDs | Our docs   |
 | ------------ | --------------- | -----------|
-|      v14.0.0 |              v5 | right here |
+|      v15.0.0 |              v6 | right here |
+|      v14.0.0 |              v5 | [/v5/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v5/main) branch |
 |      v13.0.0 |              v4 | [/v4/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v4/main) branch |
 |     v12.6.0* |              v3 | [/v3/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v3/main) branch |
 |      v12.0.0 |              v2 | [/v2/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v2/main) branch |

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Arguments.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Arguments.verified.txt
@@ -4,12 +4,12 @@
     "nullableIntId": "1",
     "nullableIntIdGivenNull": "null",
     "intIdList": "1",
-    "nullableIntIdList": "1, 0",
+    "nullableIntIdList": "1, null",
     "longId": "9223372036854775807",
     "nullableLongId": "9223372036854775807",
     "nullableLongIdGivenNull": "null",
     "longIdList": "9223372036854775807",
-    "nullableLongIdList": "9223372036854775807, 0",
+    "nullableLongIdList": "9223372036854775807, null",
     "stringId": "abc",
     "nullableStringId": "abc",
     "nullableStringIdGivenNull": "null",
@@ -19,6 +19,6 @@
     "nullableGuidId": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5",
     "nullableGuidIdGivenNull": "null",
     "guidIdList": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5, 26a2dc8f-4dab-408c-88c6-523a0a89a2b5",
-    "nullableGuidIdList": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5, 00000000-0000-0000-0000-000000000000, 26a2dc8f-4dab-408c-88c6-523a0a89a2b5"
+    "nullableGuidIdList": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5, null, 26a2dc8f-4dab-408c-88c6-523a0a89a2b5"
   }
 }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_Given_Nulls.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_Given_Nulls.verified.txt
@@ -10,7 +10,7 @@
       ],
       "someNullableIds": [
         "QmFyOjE=",
-        "QmFyOjA="
+        null
       ]
     }
   }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.cs
@@ -296,13 +296,13 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
         #region Standard ID still works
 
         // NOTE: This exercises Hot Chocolate's built-in formatter (no AddPolymorphicIds).
-        // As of HC14 there is an upstream bug where a nullable list of a value-type ID
-        // (e.g. int?[], long?[], Guid?[]) silently converts null elements to the type
-        // default (0 / Guid.Empty) instead of null - see
-        // https://github.com/ChilliCream/graphql-platform/issues/9811. The verified
-        // snapshot therefore shows e.g. "1, 0" for nullableIntIdList. Revisit (and restore
-        // null) if/when that bug is fixed upstream. Our own formatter preserves nulls
-        // correctly - see PolyId_On_Arguments.
+        // HC14 had an upstream bug where a nullable list of a value-type ID (int?[],
+        // long?[], Guid?[]) dropped null elements to the type default (0 / Guid.Empty) -
+        // see https://github.com/ChilliCream/graphql-platform/issues/9811. That was fixed
+        // in HC15.0.0 (RelayIdFieldHelpers now derives the list element type via .Source
+        // instead of .Type), so the snapshot now correctly shows "1, null" for
+        // nullableIntIdList. Our own formatter preserved nulls on HC14 too - see
+        // PolyId_On_Arguments.
         [Fact]
         public async Task Id_On_Arguments()
         {
@@ -390,11 +390,11 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
         }
 
         // NOTE: This exercises Hot Chocolate's built-in formatter (no AddPolymorphicIds).
-        // someNullableIds is a nullable list of a value-type ID, so it is affected by the
-        // upstream HC14 bug where null list elements become the type default instead of
-        // null - see https://github.com/ChilliCream/graphql-platform/issues/9811. The
-        // verified snapshot reflects that (the null becomes an encoded "0"). Revisit if/when
-        // it's fixed upstream. Our own formatter preserves nulls - see PolyId_On_Objects.
+        // someNullableIds is a nullable list of a value-type ID, which hit the upstream
+        // HC14 bug where null list elements became the type default - see
+        // https://github.com/ChilliCream/graphql-platform/issues/9811. Fixed in HC15.0.0,
+        // so the snapshot now keeps the null (rather than an encoded "0"). Our own
+        // formatter preserved nulls on HC14 too - see PolyId_On_Objects.
         [Fact]
         public async Task Id_On_Objects_Given_Nulls()
         {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Product>Polymorphic IDs.</Product>
     <Description>Polymorphic Relay IDs for HotChocolate</Description>
     <PackageTags>GraphQL HotChocolate Relay</PackageTags>
-    <Version>5.0.0</Version>
+    <Version>6.0.0</Version>
 
     <PackageProjectUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</PackageProjectUrl>
     <RepositoryUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</RepositoryUrl>
@@ -17,10 +17,10 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <HotChocolateVersion>14.0.0</HotChocolateVersion>
+    <HotChocolateVersion>15.0.0</HotChocolateVersion>
 
-    <TargetFrameworks>net8.0; net7.0; net6.0; netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildProjectName.EndsWith('Tests'))">net8.0; net7.0; net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0; net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildProjectName.EndsWith('Tests'))">net9.0; net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What & why

Adds support for **HotChocolate 15**, released as package **v6**. Continues the chain toward HC16.

**HC15 is effectively a drop-in for this library — zero production code changes.** I verified this two ways: (1) building against 15.0.0 cleanly on net8.0 + net9.0, and (2) diffing every HC API we bind to (node-id serializer, relay formatter, `TypeInterceptor`/configuration system, execution request builder) between tags `14.0.0` and `15.0.0` — all unchanged. The `*Definition` → `*Configuration` rename people associate with newer HC has **not** happened as of 15 (it's on the HC16 line — something to expect in the next PR).

## Changes

- Bump `HotChocolateVersion` → `15.0.0`, package `Version` → `6.0.0`.
- **Target frameworks** → `net8.0; net9.0` (HC15 drops `netstandard2.0`, `net6.0`, `net7.0`, so we follow per our "match HC's TFMs" policy).
- CI installs `8.0.x`/`9.0.x` runtimes (was 6/7/8).
- README compatibility table updated (v6 = HC15 "right here"; v5 → `/v5/main` branch, which I cut from the merged HC14 state).

## Tests

- All green on **net8.0 and net9.0** (21 passed, 1 skipped — the pre-existing WIP fluent-style test).
- **No test-code logic changes** — only the version bump. Two `*.verified.txt` snapshots changed, both for the **non-poly baseline** tests (`Id_On_Arguments`, `Id_On_Objects_Given_Nulls`):
  - They now **preserve nulls** in nullable value-type ID lists (`"1, null"` instead of HC14's `"1, 0"`; `["…", null]` instead of `["…", "<encoded 0>"]`).
  - This is HC15 **fixing the upstream bug we filed as ChilliCream/graphql-platform#9811** — `RelayIdFieldHelpers.CreateSerializer` now derives the list element type via `.Source` (the nullable `int?`) rather than `.Type` (`int`), exactly the fix suggested in the issue.
  - Our own formatter already preserved nulls on HC14, so the `PolyId_*` snapshots are **unchanged**. The test comments referencing #9811 are updated to note the fix.

## Merge ordering note

This branch was cut from `main` before #12 (the DIY NuGet publish workflow). The two touch **disjoint** regions of `.github/workflows/main.yml` — #12 changes the publish/release steps + `env`/`permissions`; this PR changes only the `setup-dotnet` runtime versions — so they compose without conflict regardless of merge order. (If #12 lands first, this PR will **not** reintroduce the old `rohith/publish-nuget` steps — git takes #12's publish section since this branch left it untouched relative to base.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)