### PR TITLE
Support HotChocolate 16 (v7) + modernise to .NET 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,19 +22,20 @@ jobs:
     permissions:
       contents: write # to push the version tag and create the GitHub release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Run tests
         run: dotnet test src/ --collect:"XPlat Code Coverage"
 
       - name: Publish code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration

--- a/README.md
+++ b/README.md
@@ -100,15 +100,17 @@ if I can figure out how to get that to work (last attempt failed :P).
 
 ## Compatibility
 
-We depend on [HotChocolate.Execution](https://www.nuget.org/packages/HotChocolate.Execution)
-which can bring breaking changes from time to time and require a major bump our end.
-Compatibility is listed below.
+We depend on [HotChocolate.Types](https://www.nuget.org/packages/HotChocolate.Types)
+(previously [HotChocolate.Execution](https://www.nuget.org/packages/HotChocolate.Execution), which
+Hot Chocolate stopped publishing as a standalone package in v16) which can bring breaking changes
+from time to time and require a major bump our end. Compatibility is listed below.
 
 We strive to match Hot Chocolate's supported .NET target frameworks, though this might not always be possible.
 
 | HotChocolate | Polymorphic IDs | Our docs   |
 | ------------ | --------------- | -----------|
-|      v15.0.0 |              v6 | right here |
+|      v16.0.0 |              v7 | right here |
+|      v15.0.0 |              v6 | [/v6/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v6/main) branch |
 |      v14.0.0 |              v5 | [/v5/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v5/main) branch |
 |      v13.0.0 |              v4 | [/v4/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v4/main) branch |
 |     v12.6.0* |              v3 | [/v3/main](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/tree/v3/main) branch |

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_InvalidId.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_InvalidId.verified.txt
@@ -4,12 +4,6 @@
   "errors": [
     {
       "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 33
-        }
-      ],
       "path": [
         "foo"
       ],

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_InvalidType.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Id_On_Objects_InvalidType.verified.txt
@@ -4,12 +4,6 @@
   "errors": [
     {
       "message": "No serializer registered for type `Some`.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 37
-        }
-      ],
       "path": [
         "foo"
       ],

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Arguments_Invalid_Id.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Arguments_Invalid_Id.verified.txt
@@ -1,7 +1,11 @@
 ﻿{
   "errors": [
     {
-      "message": "The ID `SomethingInvalid` has an invalid format."
+      "message": "The ID `SomethingInvalid` has an invalid format.",
+      "path": [
+        "intId"
+      ]
     }
-  ]
+  ],
+  "data": null
 }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Arguments_isEnabled=False.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Arguments_isEnabled=False.verified.txt
@@ -2,192 +2,6 @@
   "errors": [
     {
       "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 9,
-          "column": 17
-        }
-      ],
-      "path": [
-        "intId"
-      ],
-      "extensions": {
-        "originalValue": "1"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 10,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableIntId"
-      ],
-      "extensions": {
-        "originalValue": "1"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 12,
-          "column": 17
-        }
-      ],
-      "path": [
-        "intIdList"
-      ],
-      "extensions": {
-        "originalValue": "1"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 13,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableIntIdList"
-      ],
-      "extensions": {
-        "originalValue": "1"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 15,
-          "column": 17
-        }
-      ],
-      "path": [
-        "longId"
-      ],
-      "extensions": {
-        "originalValue": "9223372036854775807"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 16,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableLongId"
-      ],
-      "extensions": {
-        "originalValue": "9223372036854775807"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 18,
-          "column": 17
-        }
-      ],
-      "path": [
-        "longIdList"
-      ],
-      "extensions": {
-        "originalValue": "9223372036854775807"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 19,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableLongIdList"
-      ],
-      "extensions": {
-        "originalValue": "9223372036854775807"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 21,
-          "column": 17
-        }
-      ],
-      "path": [
-        "stringId"
-      ],
-      "extensions": {
-        "originalValue": "abc"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 22,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableStringId"
-      ],
-      "extensions": {
-        "originalValue": "abc"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 24,
-          "column": 17
-        }
-      ],
-      "path": [
-        "stringIdList"
-      ],
-      "extensions": {
-        "originalValue": "abc"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 25,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableStringIdList"
-      ],
-      "extensions": {
-        "originalValue": "abc"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 27,
-          "column": 17
-        }
-      ],
       "path": [
         "guidId"
       ],
@@ -197,27 +11,6 @@
     },
     {
       "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 28,
-          "column": 17
-        }
-      ],
-      "path": [
-        "nullableGuidId"
-      ],
-      "extensions": {
-        "originalValue": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5"
-      }
-    },
-    {
-      "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 30,
-          "column": 17
-        }
-      ],
       "path": [
         "guidIdList"
       ],
@@ -227,17 +20,128 @@
     },
     {
       "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 31,
-          "column": 17
-        }
+      "path": [
+        "intId"
       ],
+      "extensions": {
+        "originalValue": "1"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "intIdList"
+      ],
+      "extensions": {
+        "originalValue": "1"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "longId"
+      ],
+      "extensions": {
+        "originalValue": "9223372036854775807"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "longIdList"
+      ],
+      "extensions": {
+        "originalValue": "9223372036854775807"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableGuidId"
+      ],
+      "extensions": {
+        "originalValue": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
       "path": [
         "nullableGuidIdList"
       ],
       "extensions": {
         "originalValue": "26a2dc8f-4dab-408c-88c6-523a0a89a2b5"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableIntId"
+      ],
+      "extensions": {
+        "originalValue": "1"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableIntIdList"
+      ],
+      "extensions": {
+        "originalValue": "1"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableLongId"
+      ],
+      "extensions": {
+        "originalValue": "9223372036854775807"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableLongIdList"
+      ],
+      "extensions": {
+        "originalValue": "9223372036854775807"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableStringId"
+      ],
+      "extensions": {
+        "originalValue": "abc"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "nullableStringIdList"
+      ],
+      "extensions": {
+        "originalValue": "abc"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "stringId"
+      ],
+      "extensions": {
+        "originalValue": "abc"
+      }
+    },
+    {
+      "message": "The node ID string has an invalid format.",
+      "path": [
+        "stringIdList"
+      ],
+      "extensions": {
+        "originalValue": "abc"
       }
     }
   ],

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_Invalid_Id.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_Invalid_Id.verified.txt
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The IDs `SomethingInvalid` have an invalid format.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 37
-        }
-      ],
       "path": [
         "foo"
       ]

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_isEnabled=False.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_isEnabled=False.verified.txt
@@ -2,12 +2,6 @@
   "errors": [
     {
       "message": "The node ID string has an invalid format.",
-      "locations": [
-        {
-          "line": 2,
-          "column": 37
-        }
-      ],
       "path": [
         "foo"
       ],

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Schema.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.Schema.verified.txt
@@ -2,22 +2,6 @@
   query: Query
 }
 
-interface IFooPayload {
-  someId: ID!
-  someNullableId: ID
-  someIds: [ID!]!
-  someNullableIds: [ID]
-  raw: String!
-}
-
-type FooPayload implements IFooPayload {
-  someId: ID!
-  someIds: [ID!]!
-  someNullableId: ID
-  someNullableIds: [ID]
-  raw: String!
-}
-
 type Query {
   intId(id: ID!): String!
   intIdList(id: [ID!]!): String!
@@ -37,6 +21,22 @@ type Query {
   nullableGuidIdList(id: [ID]!): String!
   foo(input: FooInput!): IFooPayload!
   lol(input: LolInput!): Int!
+}
+
+type FooPayload implements IFooPayload {
+  someId: ID!
+  someIds: [ID!]!
+  someNullableId: ID
+  someNullableIds: [ID]
+  raw: String!
+}
+
+interface IFooPayload {
+  someId: ID!
+  someNullableId: ID
+  someIds: [ID!]!
+  someNullableIds: [ID]
+  raw: String!
 }
 
 input FooInput {

--- a/src/AutoGuru.HotChocolate.PolymorphicIds/AutoGuru.HotChocolate.PolymorphicIds.csproj
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds/AutoGuru.HotChocolate.PolymorphicIds.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.Execution" Version="$(HotChocolateVersion)" />
+    <PackageReference Include="HotChocolate.Types" Version="$(HotChocolateVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsSchemaBuilderExtensions.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsSchemaBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AutoGuru.HotChocolate.Types.Relay;
 using HotChocolate;
+using HotChocolate.Features;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -15,10 +16,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            options ??= new PolymorphicIdsOptions();
-            
+            // As of HC16 the string-keyed schema context data is replaced by the typed
+            // feature collection, so we stash the options as a feature keyed by their type.
+            builder.Features.Set(options ?? new PolymorphicIdsOptions());
+
             return builder
-                .SetContextData(typeof(PolymorphicIdsOptions).FullName!, options)
                 .TryAddTypeInterceptor<PolymorphicIdsTypeInterceptor>();
         }
     }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsTypeInterceptor.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsTypeInterceptor.cs
@@ -5,7 +5,7 @@ using HotChocolate.Configuration;
 using HotChocolate.Internal;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
-using HotChocolate.Types.Descriptors.Definitions;
+using HotChocolate.Types.Descriptors.Configurations;
 using HotChocolate.Types.Relay;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,8 +15,10 @@ namespace AutoGuru.HotChocolate.Types.Relay
     {
         private const string StandardGlobalIdFormatterName = "GlobalIdInputValueFormatter";
 
-        // /src/HotChocolate/Core/src/Abstractions/WellKnownContextData.cs
-        private const string GlobalIdSupportEnabledContextDataKey = "HotChocolate.Relay.GlobalId";
+        // As of HC16, global ID support is tracked by an internal NodeSchemaFeature in the
+        // feature collection (rather than the old "HotChocolate.Relay.GlobalId" context-data
+        // key). We can't reference the internal type, so we detect it by name.
+        private const string NodeSchemaFeatureName = "NodeSchemaFeature";
 
         private PolymorphicIdsOptions? _options;
         private PolymorphicIdsOptions Options =>
@@ -24,10 +26,11 @@ namespace AutoGuru.HotChocolate.Types.Relay
 
         public override void OnBeforeCompleteType(
             ITypeCompletionContext completionContext,
-            DefinitionBase definition)
+            TypeSystemConfiguration definition)
         {
-            var globalContextData = completionContext.ContextData;
-            if (!globalContextData.ContainsKey(GlobalIdSupportEnabledContextDataKey))
+            var globalIdSupportEnabled = completionContext.Features
+                .Any(f => f.Key.Name == NodeSchemaFeatureName);
+            if (!globalIdSupportEnabled)
             {
                 var error = SchemaErrorBuilder.New()
                     .SetMessage(
@@ -39,17 +42,14 @@ namespace AutoGuru.HotChocolate.Types.Relay
                 throw new SchemaException(error);
             }
 
-            if (completionContext.ContextData.TryGetValue(
-                    typeof(PolymorphicIdsOptions).FullName!,
-                    out var o) &&
-                o is PolymorphicIdsOptions options)
+            if (completionContext.Features.Get<PolymorphicIdsOptions>() is { } options)
             {
                 _options = options;
             }
 
-            if (definition is InputObjectTypeDefinition inputObjectTypeDefinition)
+            if (definition is InputObjectTypeConfiguration inputObjectTypeConfiguration)
             {
-                foreach (var inputFieldDefinition in inputObjectTypeDefinition.Fields)
+                foreach (var inputFieldDefinition in inputObjectTypeConfiguration.Fields)
                 {
                     var idInfo = GetIdInfo(completionContext, inputFieldDefinition);
                     if (idInfo != null && ShouldIntercept(idInfo.Value.IdRuntimeType))
@@ -61,11 +61,11 @@ namespace AutoGuru.HotChocolate.Types.Relay
                     }
                 }
             }
-            else if (definition is ObjectTypeDefinition objectTypeDefinition)
+            else if (definition is ObjectTypeConfiguration objectTypeConfiguration)
             {
                 var isQueryType = definition.Name == OperationTypeNames.Query;
 
-                foreach (var objectFieldDefinition in objectTypeDefinition.Fields)
+                foreach (var objectFieldDefinition in objectTypeConfiguration.Fields)
                 {
                     if (isQueryType && objectFieldDefinition.Name == "node")
                     {
@@ -94,24 +94,24 @@ namespace AutoGuru.HotChocolate.Types.Relay
         // BeforeCompletion configuration (appended after Hot Chocolate's) that runs in the same
         // phase, by which time the default formatter is present and can be replaced.
         private static void DeferFormatterReplacement(
-            ArgumentDefinition argumentDefinition,
+            ArgumentConfiguration argumentConfiguration,
             string typeName,
             Type idRuntimeType)
         {
-            argumentDefinition.Configurations.Add(
-                new CompleteConfiguration(
+            argumentConfiguration.Tasks.Add(
+                new OnCompleteTypeSystemConfigurationTask(
                     (completionContext, _) => InsertFormatter(
                         completionContext,
-                        argumentDefinition,
+                        argumentConfiguration,
                         typeName,
                         idRuntimeType),
-                    argumentDefinition,
+                    argumentConfiguration,
                     ApplyConfigurationOn.BeforeCompletion));
         }
 
         private static void InsertFormatter(
             ITypeCompletionContext completionContext,
-            ArgumentDefinition argumentDefinition,
+            ArgumentConfiguration argumentConfiguration,
             string typeName,
             Type idRuntimeType)
         {
@@ -120,7 +120,7 @@ namespace AutoGuru.HotChocolate.Types.Relay
                 idRuntimeType,
                 completionContext.DescriptorContext.NodeIdSerializerAccessor);
 
-            var formatters = argumentDefinition.Formatters;
+            var formatters = argumentConfiguration.Formatters;
             var defaultFormatter = formatters
                 .FirstOrDefault(f => f.GetType().Name == StandardGlobalIdFormatterName);
 
@@ -169,13 +169,13 @@ namespace AutoGuru.HotChocolate.Types.Relay
 
         private static (string NodeTypeName, Type IdRuntimeType)? GetIdInfo(
             ITypeCompletionContext completionContext,
-            ArgumentDefinition definition)
+            ArgumentConfiguration definition)
         {
             var typeInspector = completionContext.TypeInspector;
             IDAttribute? idAttribute = null;
             IExtendedType? idType = null;
 
-            if (definition is InputFieldDefinition inputField)
+            if (definition is InputFieldConfiguration inputField)
             {
                 // UseSorting arg/s seems to come in here with a null Property
                 if (inputField.Property == null)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Product>Polymorphic IDs.</Product>
     <Description>Polymorphic Relay IDs for HotChocolate</Description>
     <PackageTags>GraphQL HotChocolate Relay</PackageTags>
-    <Version>6.0.0</Version>
+    <Version>7.0.0</Version>
 
     <PackageProjectUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</PackageProjectUrl>
     <RepositoryUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</RepositoryUrl>
@@ -17,10 +17,10 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <HotChocolateVersion>15.0.0</HotChocolateVersion>
+    <HotChocolateVersion>16.0.0</HotChocolateVersion>
 
-    <TargetFrameworks>net9.0; net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildProjectName.EndsWith('Tests'))">net9.0; net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0; net9.0; net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildProjectName.EndsWith('Tests'))">net10.0; net9.0; net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What & why

Brings the library to **HotChocolate 16**, released as package **v7**, and modernises the repo to **.NET 10**. This completes the HC13→HC16 upgrade chain.

HC16 was the largest jump by far — three substantial changes plus the .NET 10 work.

## 1. Packaging change ⚠️

HotChocolate **stopped publishing the standalone `HotChocolate.Execution` package in v16** (it has no stable 16.x — only old previews). The type-system + execution APIs we use are now surfaced via **`HotChocolate.Types`**, so our `PackageReference` switches `HotChocolate.Execution` → `HotChocolate.Types`.

Per our "earliest public stable" rule, v7 targets **`HotChocolate.Types` 16.0.0** (the meta-package and several others only start at 16.0.4, but `HotChocolate.Types` 16.0.0 is public). Package version → **7.0.0** (stable, per decision — the dependency is a stable HC release).

## 2. API migration — the `*Definition` → `*Configuration` rename

HC16 renamed the type-system configuration API:
- `DefinitionBase` → `TypeSystemConfiguration`; `ArgumentDefinition` → `ArgumentConfiguration`; `InputObjectTypeDefinition`/`ObjectTypeDefinition`/`InputFieldDefinition` → `*Configuration`.
- Namespace `HotChocolate.Types.Descriptors.Definitions` → `...Configurations`.
- Deferred config: `definition.Configurations.Add(new CompleteConfiguration(...))` → `configuration.Tasks.Add(new OnCompleteTypeSystemConfigurationTask(...))`.

## 3. Context data → typed Features

HC16 replaced string-keyed context data with a typed feature collection:
- Options are stashed via `builder.Features.Set(options)` and read with `completionContext.Features.Get<PolymorphicIdsOptions>()` (cleaner — keyed by type, no magic string).
- Global-ID support is now tracked by an internal `NodeSchemaFeature`. Since we can't reference an internal type, we detect it by name in the feature collection (same pragmatic approach we already use to find the built-in `GlobalIdInputValueFormatter`).

## 4. .NET 10 modernisation

- Target frameworks → **net8.0; net9.0; net10.0** (HC16 added net10).
- Added **`global.json`** pinning the .NET 10 SDK.
- **CI action bumps** (answering the "anything else worth upgrading?" question): `actions/checkout` v4→**v5**, `actions/setup-dotnet` v3→**v5** (now also installs the `10.0.x` runtime), `codecov/codecov-action` v3→**v5** (v3 was deprecated).

## Tests

- Green on **net8.0 / net9.0 / net10.0** (21 passed, 1 skipped — the pre-existing WIP fluent-style test).
- **No test-code logic changed.** Updated `*.verified.txt` snapshots reflect **HC16 framework output changes only**:
  - `Schema` SDL: HC16 emits types in a different order (`Query` first); per-type content is byte-identical (verified by set-diff).
  - Error-envelope tests: HC16 no longer includes `locations` in these execution errors (and adds `path`/`data:null` in one case). **Error messages and decoded ID values are unchanged.**
  - The core `PolyId_*` (isEnabled: true) snapshots were **unaffected**, confirming our polymorphic behaviour is identical on HC16.

## README

Compatibility table updated (v7 = HC16 "right here"; v6 → `/v6/main`, cut from the merged HC15 state). Compatibility note updated to reflect the `HotChocolate.Types` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)