### PR TITLE
Backport fluent .ID() + type-name validation to v5 (HC14) — 5.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,20 +8,22 @@ on:
       - '*.props'
       - '**/*.yml'
       - '!**/*.md'
-      
+
   pull_request: {}
 
 env:
   VERSION_FILE_PATH: src/Directory.Build.props
-  NUGET_KEY: ${{ secrets.NUGET_KEY }}
-  TAG_COMMIT: false
+  PROJECT_FILE_PATH: src/AutoGuru.HotChocolate.PolymorphicIds/AutoGuru.HotChocolate.PolymorphicIds.csproj
+  PACKAGE_ID: AutoGuru.HotChocolate.PolymorphicIds
 jobs:
   test_and_publish_if_allowed:
     name: test and publish if allowed
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the version tag and create the GitHub release
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
@@ -31,7 +33,7 @@ jobs:
 
       - name: Run tests
         run: dotnet test src/ --collect:"XPlat Code Coverage"
-        
+
       - name: Publish code coverage
         uses: codecov/codecov-action@v3
         with:
@@ -39,22 +41,60 @@ jobs:
           flags: integration
           files: src/AutoGuru.HotChocolate.PolymorphicIds.Tests/TestResults/*/coverage.cobertura.xml
 
-      - name: Publish to NuGet on version change
-        if: ${{ endsWith(github.ref, 'main') }}
-        id: publish_nuget
-        uses: rohith/publish-nuget@v2.5.5
-        with:
-          PROJECT_FILE_PATH: src/AutoGuru.HotChocolate.PolymorphicIds/AutoGuru.HotChocolate.PolymorphicIds.csproj
-          TAG_COMMIT: true
-          
-      - name: Create Release
-        if: ${{ success() && steps.publish_nuget.outputs.VERSION }}
-        id: create_release
-        uses: actions/create-release@latest
+      # --- Publish: pack -> push to NuGet -> tag + GitHub release ---
+      # Replaces the former rohith/publish-nuget and actions/create-release actions
+      # with first-party tooling (dotnet CLI + gh) so we don't depend on third-party
+      # actions referenced by movable tags. Only runs on *main branches, and only when
+      # the version in Directory.Build.props isn't already on NuGet (idempotent).
+
+      - name: Read package version
+        id: version
+        run: |
+          version=$(grep -oPm1 '(?<=<Version>)[^<]+' "$VERSION_FILE_PATH")
+          if [ -z "$version" ]; then
+            echo "::error::Could not read <Version> from $VERSION_FILE_PATH"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $version"
+
+      - name: Check whether version is already on NuGet
+        id: check
+        run: |
+          id_lower=$(echo "$PACKAGE_ID" | tr '[:upper:]' '[:lower:]')
+          versions=$(curl -fsSL "https://api.nuget.org/v3-flatcontainer/${id_lower}/index.json" || echo '{"versions":[]}')
+          if echo "$versions" | grep -q "\"${{ steps.version.outputs.version }}\""; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.version.outputs.version }} is already published; nothing to do."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.version.outputs.version }} is new."
+          fi
+
+      - name: Pack
+        if: ${{ endsWith(github.ref, 'main') && steps.check.outputs.published == 'false' }}
+        run: dotnet pack "$PROJECT_FILE_PATH" -c Release -o artifacts
+
+      - name: Push to NuGet
+        if: ${{ endsWith(github.ref, 'main') && steps.check.outputs.published == 'false' }}
+        run: dotnet nuget push "artifacts/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_KEY" --skip-duplicate
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.publish_nuget.outputs.VERSION }}
-          release_name: ${{ steps.publish_nuget.outputs.VERSION }}
-          draft: false
-          prerelease: ${{ contains(steps.publish_nuget.outputs.VERSION, 'preview') || contains(steps.publish_nuget.outputs.VERSION, 'rc') }}
+          NUGET_KEY: ${{ secrets.NUGET_KEY }}
+
+      - name: Tag and create GitHub release
+        if: ${{ endsWith(github.ref, 'main') && steps.check.outputs.published == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          prerelease=""
+          case "$VERSION" in
+            *preview*|*rc*|*-*) prerelease="--prerelease" ;;
+          esac
+          # gh creates the tag at the target commit if it doesn't already exist.
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --generate-notes \
+            $prerelease

--- a/README.md
+++ b/README.md
@@ -44,9 +44,22 @@ query {
 
 ### What's supported?
 
-Currently only arguments / input fields that are annotated with the `[ID]` attribute will be noticed and have support added for handling different ids.
-Specifically, the fluent-style declaration `.ID()` won't be handled right now; though support could 
-be added for it in the future so shout out if you need it on the [open issue](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/issues/5).
+Arguments / input fields are noticed whether they're declared with the `[ID]` attribute or the
+fluent-style `.ID()` (e.g. `descriptor.Field(x => x.SomeId).ID()`); both have polymorphic id
+handling added.
+
+When a field declares an explicit type name **via the attribute** (e.g. `[ID("Booking")]`), an
+incoming *global* id is validated to actually belong to that type — a global id for a different
+type is rejected, just like Hot Chocolate's built-in behaviour. Raw database ids carry no type
+name, so they're always accepted (that's the whole point).
+
+> **Limitation:** this type-name validation is **not** applied to the fluent `.ID("Booking")`
+> form. Fluent ids are still fully handled (raw db ids and global ids both work), but the
+> explicit type name passed to `.ID(...)` isn't visible to us (Hot Chocolate keeps it inside its
+> own formatter), so a global id of the wrong type won't be rejected on a fluently-declared
+> field. Use the `[ID("Booking")]` attribute if you need that check. If you'd like this
+> supported for fluent fields too, give
+> [issue #16](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/issues/16) a 👍.
 
 Arrays of IDs are handled (but only v2+ can support arrays of nullable IDs (`[ID]` or `[ID]!`) due to a bug in Hot Chocolate v11).
 

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_Explicit_TypeName_Accepts_RawId_And_MatchingType.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_Explicit_TypeName_Accepts_RawId_And_MatchingType.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  "data": {
+    "byRawId": "1",
+    "byMatchingTypeName": "1"
+  }
+}

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_Explicit_TypeName_Rejects_GlobalId_Of_Wrong_Type.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_Explicit_TypeName_Rejects_GlobalId_Of_Wrong_Type.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  "errors": [
+    {
+      "message": "The ID `Tm90QVRoaW5nOjE=` is not an ID of `Thing`.",
+      "locations": [
+        {
+          "line": 1,
+          "column": 20
+        }
+      ],
+      "path": [
+        "thing"
+      ]
+    }
+  ],
+  "data": null
+}

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_FluentStyle.verified.txt
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.PolyId_On_Objects_FluentStyle.verified.txt
@@ -1,0 +1,60 @@
+﻿{
+  schema:
+schema {
+  query: Query
+}
+
+interface IFooPayload {
+  someId: ID!
+  someNullableId: ID
+  someIds: [ID!]!
+  someNullableIds: [ID]
+  raw: String!
+}
+
+type FooPayload implements IFooPayload {
+  someId: ID!
+  someIds: [ID!]!
+  someNullableId: ID
+  someNullableIds: [ID]
+  raw: String!
+}
+
+type Query {
+  intId(id: ID!): String!
+  intIdList(id: [ID!]!): String!
+  nullableIntId(id: ID): String!
+  nullableIntIdList(id: [ID]!): String!
+  longId(id: ID!): String!
+  longIdList(id: [ID!]!): String!
+  nullableLongId(id: ID): String!
+  nullableLongIdList(id: [ID]!): String!
+  stringId(id: ID!): String!
+  stringIdList(id: [ID!]!): String!
+  nullableStringId(id: ID): String!
+  nullableStringIdList(id: [ID]!): String!
+  guidId(id: ID!): String!
+  guidIdList(id: [ID!]!): String!
+  nullableGuidId(id: ID): String!
+  nullableGuidIdList(id: [ID]!): String!
+  foo(input: FooInput!): IFooPayload!
+  lol(input: LolInput!): Int!
+}
+
+input FooInput {
+  someId: ID!
+  someNullableId: ID
+  someIds: [ID!]!
+  someNullableIds: [ID]
+}
+
+input LolInput {
+  someIdCustomName: ID!
+},
+  result:
+{
+  "data": {
+    "lol": 1
+  }
+}
+}

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/IdAttributeTests.cs
@@ -253,8 +253,11 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
             await Verifier.Verify(result.ToJson());
         }
 
-        [Fact(Skip = "WIP, not yet supported")]
-        public async Task PolyId_On_Objects_Invalid_Id_FluentStyle()
+        // Fluent-style `.ID()` (rather than the [ID] attribute) is now supported - see issue #5.
+        // LolInputType configures `someIdCustomName` as an ID via descriptor.Field(...).ID("Some"),
+        // so a raw database id ("1") should be accepted polymorphically just like an attribute ID.
+        [Fact]
+        public async Task PolyId_On_Objects_FluentStyle()
         {
             // arrange
             var someId = "1";
@@ -291,6 +294,69 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
                     schema = schema.ToString(),
                     result = result.ToJson()
                 });
+        }
+
+        // When a field declares an explicit type name (e.g. [ID("Thing")]), an incoming *global
+        // id* for a different type is rejected, matching Hot Chocolate's own type-name
+        // validation.
+        [Fact]
+        public async Task PolyId_Explicit_TypeName_Rejects_GlobalId_Of_Wrong_Type()
+        {
+            // arrange
+            var wrongTypeId = new DefaultNodeIdSerializer().Format("NotAThing", 1);
+
+            // act
+            var result =
+                await SchemaBuilder.New()
+                    .AddQueryType<TypeNameQuery>()
+                    .AddGlobalObjectIdentification(registerNodeInterface: false)
+                    .AddPolymorphicIds()
+                    .Create()
+                    .MakeExecutable(_executorOptions)
+                    .ExecuteAsync(
+                        OperationRequestBuilder.New()
+                            .SetDocument(@"query ($id: ID!) { thing(id: $id) }")
+                            .SetVariableValues(new Dictionary<string, object?>
+                            {
+                                ["id"] = wrongTypeId,
+                            })
+                            .Build());
+
+            // assert
+            await Verifier.Verify(result.ToJson());
+        }
+
+        // Raw database ids (no type name) and global ids of the matching type are both accepted.
+        [Fact]
+        public async Task PolyId_Explicit_TypeName_Accepts_RawId_And_MatchingType()
+        {
+            // arrange
+            var matchingTypeId = new DefaultNodeIdSerializer().Format("Thing", 1);
+
+            // act
+            var result =
+                await SchemaBuilder.New()
+                    .AddQueryType<TypeNameQuery>()
+                    .AddGlobalObjectIdentification(registerNodeInterface: false)
+                    .AddPolymorphicIds()
+                    .Create()
+                    .MakeExecutable(_executorOptions)
+                    .ExecuteAsync(
+                        OperationRequestBuilder.New()
+                            .SetDocument(
+                                @"query ($raw: ID! $matching: ID!) {
+                                    byRawId: thing(id: $raw)
+                                    byMatchingTypeName: thing(id: $matching)
+                                }")
+                            .SetVariableValues(new Dictionary<string, object?>
+                            {
+                                ["raw"] = "1",
+                                ["matching"] = matchingTypeId,
+                            })
+                            .Build());
+
+            // assert: both resolve to "1", no errors.
+            await Verifier.Verify(result.ToJson());
         }
 
         #region Standard ID still works
@@ -677,6 +743,12 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
             {
                 descriptor.Field(x => x.SomeId).Name("someIdCustomName").ID("Some");
             }
+        }
+
+        [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Can't be static for HC")]
+        public class TypeNameQuery
+        {
+            public string Thing([ID("Thing")] int id) => id.ToString();
         }
     }
 }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/PolymorphicIdInputValueFormatterTests.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds.Tests/PolymorphicIdInputValueFormatterTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using AutoGuru.HotChocolate.Types.Relay;
+using HotChocolate;
 using HotChocolate.Types.Relay;
 using Shouldly;
 using Xunit;
@@ -13,8 +14,9 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
             public INodeIdSerializer Serializer { get; } = new DefaultNodeIdSerializer();
         }
 
-        private static PolymorphicIdInputValueFormatter CreateSut(System.Type idRuntimeType) =>
-            new("Some", idRuntimeType, new StubAccessor());
+        private static PolymorphicIdInputValueFormatter CreateSut(
+            System.Type idRuntimeType, string? expectedTypeName = null) =>
+            new(idRuntimeType, expectedTypeName, new StubAccessor());
 
         [Fact]
         public void Format_Null_Returns_Null()
@@ -71,6 +73,34 @@ namespace AutoGuru.HotChocolate.PolymorphicIds.Tests
 
             result.ShouldBeAssignableTo<int?[]>();
             ((int?[])result!).ShouldBe(new int?[] { 1, null, 2 });
+        }
+
+        [Fact]
+        public void Format_GlobalId_With_Matching_TypeName_Is_Accepted()
+        {
+            var globalId = new DefaultNodeIdSerializer().Format("Some", 7);
+            var sut = CreateSut(typeof(int), expectedTypeName: "Some");
+
+            sut.Format(globalId).ShouldBe(7);
+        }
+
+        [Fact]
+        public void Format_GlobalId_With_Wrong_TypeName_Throws()
+        {
+            var globalId = new DefaultNodeIdSerializer().Format("Other", 7);
+            var sut = CreateSut(typeof(int), expectedTypeName: "Some");
+
+            Should.Throw<GraphQLException>(() => sut.Format(globalId));
+        }
+
+        [Fact]
+        public void Format_RawId_Bypasses_TypeName_Validation()
+        {
+            // Raw db ids carry no type name, so they're accepted even when an explicit
+            // type name is expected (this is the whole point of the library).
+            var sut = CreateSut(typeof(int), expectedTypeName: "Some");
+
+            sut.Format("1").ShouldBe(1);
         }
     }
 }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdInputValueFormatter.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdInputValueFormatter.cs
@@ -8,20 +8,26 @@ namespace AutoGuru.HotChocolate.Types.Relay
 {
     internal sealed class PolymorphicIdInputValueFormatter : IInputValueFormatter
     {
-        private readonly string _nodeTypeName;
         private readonly Type _idRuntimeType;
         private readonly Type _underlyingIdRuntimeType;
+        private readonly string? _expectedTypeName;
         private readonly INodeIdSerializerAccessor _serializerAccessor;
         private INodeIdSerializer? _serializer;
 
+        /// <param name="expectedTypeName">
+        /// The node type name an incoming global id must decode to, or <c>null</c> to skip the
+        /// check. This is only set when the field declares an explicit type name (e.g.
+        /// <c>[ID("Booking")]</c>), mirroring Hot Chocolate's own type-name validation. Raw
+        /// (database) ids carry no type name and are always accepted.
+        /// </param>
         public PolymorphicIdInputValueFormatter(
-            string nodeTypeName,
             Type idRuntimeType,
+            string? expectedTypeName,
             INodeIdSerializerAccessor serializerAccessor)
         {
-            _nodeTypeName = nodeTypeName;
             _idRuntimeType = idRuntimeType;
             _underlyingIdRuntimeType = Nullable.GetUnderlyingType(idRuntimeType) ?? idRuntimeType;
+            _expectedTypeName = expectedTypeName;
             _serializerAccessor = serializerAccessor;
         }
 
@@ -74,6 +80,7 @@ namespace AutoGuru.HotChocolate.Types.Relay
             // Already an internal id (e.g. a NodeId produced upstream) - unwrap it.
             if (runtimeValue is NodeId nodeId)
             {
+                ValidateTypeName(nodeId.TypeName, nodeId.ToString());
                 return nodeId.InternalId;
             }
 
@@ -103,9 +110,10 @@ namespace AutoGuru.HotChocolate.Types.Relay
 
             _serializer ??= _serializerAccessor.Serializer;
 
+            NodeId nodeId;
             try
             {
-                return _serializer.Parse(value, _underlyingIdRuntimeType).InternalId;
+                nodeId = _serializer.Parse(value, _underlyingIdRuntimeType);
             }
             catch
             {
@@ -116,12 +124,32 @@ namespace AutoGuru.HotChocolate.Types.Relay
                 {
                     return value;
                 }
+
+                throw new GraphQLException(
+                    ErrorBuilder.New()
+                        .SetMessage("The ID `{0}` has an invalid format.", value)
+                        .Build());
             }
 
-            throw new GraphQLException(
-                ErrorBuilder.New()
-                    .SetMessage("The ID `{0}` has an invalid format.", value)
-                    .Build());
+            // It decoded to a valid global id - if the field declares an explicit type name,
+            // make sure the id actually belongs to that type (raw db ids never reach here).
+            ValidateTypeName(nodeId.TypeName, value);
+            return nodeId.InternalId;
+        }
+
+        private void ValidateTypeName(string actualTypeName, string formattedValue)
+        {
+            if (_expectedTypeName is not null &&
+                !string.Equals(actualTypeName, _expectedTypeName, StringComparison.Ordinal))
+            {
+                throw new GraphQLException(
+                    ErrorBuilder.New()
+                        .SetMessage(
+                            "The ID `{0}` is not an ID of `{1}`.",
+                            formattedValue,
+                            _expectedTypeName)
+                        .Build());
+            }
         }
     }
 }

--- a/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsTypeInterceptor.cs
+++ b/src/AutoGuru.HotChocolate.PolymorphicIds/PolymorphicIdsTypeInterceptor.cs
@@ -52,12 +52,10 @@ namespace AutoGuru.HotChocolate.Types.Relay
                 foreach (var inputFieldDefinition in inputObjectTypeDefinition.Fields)
                 {
                     var idInfo = GetIdInfo(completionContext, inputFieldDefinition);
-                    if (idInfo != null && ShouldIntercept(idInfo.Value.IdRuntimeType))
+                    if (idInfo is { } info && ShouldIntercept(info.RuntimeType))
                     {
                         DeferFormatterReplacement(
-                            inputFieldDefinition,
-                            idInfo.Value.NodeTypeName,
-                            idInfo.Value.IdRuntimeType);
+                            inputFieldDefinition, info.RuntimeType, info.ExpectedTypeName);
                     }
                 }
             }
@@ -75,12 +73,10 @@ namespace AutoGuru.HotChocolate.Types.Relay
                     foreach (var argumentDefinition in objectFieldDefinition.Arguments)
                     {
                         var idInfo = GetIdInfo(completionContext, argumentDefinition);
-                        if (idInfo != null && ShouldIntercept(idInfo.Value.IdRuntimeType))
+                        if (idInfo is { } info && ShouldIntercept(info.RuntimeType))
                         {
                             DeferFormatterReplacement(
-                                argumentDefinition,
-                                idInfo.Value.NodeTypeName,
-                                idInfo.Value.IdRuntimeType);
+                                argumentDefinition, info.RuntimeType, info.ExpectedTypeName);
                         }
                     }
                 }
@@ -95,16 +91,16 @@ namespace AutoGuru.HotChocolate.Types.Relay
         // phase, by which time the default formatter is present and can be replaced.
         private static void DeferFormatterReplacement(
             ArgumentDefinition argumentDefinition,
-            string typeName,
-            Type idRuntimeType)
+            Type idRuntimeType,
+            string? expectedTypeName)
         {
             argumentDefinition.Configurations.Add(
                 new CompleteConfiguration(
                     (completionContext, _) => InsertFormatter(
                         completionContext,
                         argumentDefinition,
-                        typeName,
-                        idRuntimeType),
+                        idRuntimeType,
+                        expectedTypeName),
                     argumentDefinition,
                     ApplyConfigurationOn.BeforeCompletion));
         }
@@ -112,12 +108,12 @@ namespace AutoGuru.HotChocolate.Types.Relay
         private static void InsertFormatter(
             ITypeCompletionContext completionContext,
             ArgumentDefinition argumentDefinition,
-            string typeName,
-            Type idRuntimeType)
+            Type idRuntimeType,
+            string? expectedTypeName)
         {
             var formatter = new PolymorphicIdInputValueFormatter(
-                typeName,
                 idRuntimeType,
+                expectedTypeName,
                 completionContext.DescriptorContext.NodeIdSerializerAccessor);
 
             var formatters = argumentDefinition.Formatters;
@@ -167,70 +163,75 @@ namespace AutoGuru.HotChocolate.Types.Relay
             return true;
         }
 
-        private static (string NodeTypeName, Type IdRuntimeType)? GetIdInfo(
+        // Resolves the CLR runtime type of an id field/argument and the node type name it must
+        // validate against, or null if it isn't a relay ID we should handle. A field is treated
+        // as a relay ID if it carries the [ID] attribute (attribute style) or its GraphQL type
+        // was rewritten to IdType - both the attribute and the fluent `.ID()` declaration do
+        // this before completion, which is how we support fluent-style ids (see issue #5).
+        //
+        // ExpectedTypeName is only set when an explicit type name was declared (e.g.
+        // `[ID("Booking")]`), mirroring Hot Chocolate's own type-name validation; it's null for
+        // a bare `[ID]` (and for fluent ids, whose explicit name isn't reachable here).
+        private static (Type RuntimeType, string? ExpectedTypeName)? GetIdInfo(
             ITypeCompletionContext completionContext,
             ArgumentDefinition definition)
         {
             var typeInspector = completionContext.TypeInspector;
-            IDAttribute? idAttribute = null;
-            IExtendedType? idType = null;
+            IDAttribute? idAttribute;
+            IExtendedType? idType;
 
             if (definition is InputFieldDefinition inputField)
             {
                 // UseSorting arg/s seems to come in here with a null Property
-                if (inputField.Property == null)
+                if (inputField.Property is null)
                 {
                     return null;
                 }
 
-                idAttribute = (IDAttribute?)inputField.Property
-                   .GetCustomAttributes(inherit: true)
-                   .SingleOrDefault(a => a is IDAttribute);
-                if (idAttribute == null)
-                {
-                    return null;
-                }
+                idAttribute = inputField.Property
+                    .GetCustomAttributes(inherit: true)
+                    .OfType<IDAttribute>()
+                    .FirstOrDefault();
 
                 idType = typeInspector.GetReturnType(inputField.Property, true);
             }
             else if (definition.Parameter is not null)
             {
-                idAttribute = (IDAttribute?)definition.Parameter
+                idAttribute = definition.Parameter
                     .GetCustomAttributes(inherit: true)
-                    .SingleOrDefault(a => a is IDAttribute);
-                if (idAttribute == null)
-                {
-                    return null;
-                }
+                    .OfType<IDAttribute>()
+                    .FirstOrDefault();
 
                 idType = typeInspector.GetArgumentType(definition.Parameter, true);
             }
-            else if (definition.Type is ExtendedTypeReference typeReference)
+            else
             {
-                if (typeReference.Type.Kind == ExtendedTypeKind.Schema)
-                {
-                    return null;
-                }
+                // Purely code-first fields/args with no backing CLR member: we can't determine
+                // the runtime id type, so there's nothing for us to convert.
+                return null;
             }
-            else if (definition.Type is SyntaxTypeReference syntaxTypeReference)
+
+            if (idType is null)
             {
                 return null;
             }
 
-            if (idAttribute is null || idType is null)
+            if (idAttribute is null && !IsIdType(completionContext, definition))
             {
-                throw new SchemaException(SchemaErrorBuilder.New()
-                    .SetMessage("Unable to resolve type from field `{0}`.", definition.Name)
-                    .SetTypeSystemObject(completionContext.Type)
-                    .Build());
+                return null;
             }
 
-            var idRuntimeType = idType.ElementType?.Source ?? idType.Source;
-            var nodeTypeName = idAttribute?.TypeName != null
-                ? idAttribute.TypeName
-                : completionContext.Type.Name;
-
-            return (nodeTypeName, idRuntimeType);
+            var runtimeType = idType.ElementType?.Source ?? idType.Source;
+            return (runtimeType, idAttribute?.TypeName);
         }
+
+        // True if the field/argument's (already rewritten) GraphQL type is the relay IdType.
+        // Both [ID] and the fluent `.ID()` rewrite the type to IdType before completion.
+        private static bool IsIdType(
+            ITypeCompletionContext completionContext,
+            ArgumentDefinition definition)
+            => definition.Type is ExtendedTypeReference typeReference
+                && completionContext.TypeInspector
+                    .CreateTypeInfo(typeReference.Type).NamedType == typeof(IdType);
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Product>Polymorphic IDs.</Product>
     <Description>Polymorphic Relay IDs for HotChocolate</Description>
     <PackageTags>GraphQL HotChocolate Relay</PackageTags>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
 
     <PackageProjectUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</PackageProjectUrl>
     <RepositoryUrl>https://github.com/autoguru-au/hotchocolate-polymorphic-ids</RepositoryUrl>


### PR DESCRIPTION
Backports the v7 improvements to **v5 (HotChocolate 14)** as **5.1.0**.

## What

1. **Fluent `.ID()` support** (was only `[ID]` attribute) — closes the v5 gap on [#5](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/issues/5). Detection now matches a relay id via the attribute **or** its GraphQL type being rewritten to `IdType` (both the attribute and `.ID()` do this before completion). The deferred replace-HC's-formatter mechanism is unchanged.
2. **Type-name validation for `[ID("Type")]`** — an incoming *global* id is validated to belong to that type; a global id for a different type is rejected, matching HC's built-in behaviour. Raw db ids are always accepted. This was effectively lost in v5 when we began *replacing* HC's `GlobalIdInputValueFormatter`, so we now do it in our own formatter. (Fluent `.ID("Type")` isn't type-validated — its name isn't reachable from the field — tracked in [#16](https://github.com/autoguru-au/hotchocolate-polymorphic-ids/issues/16).)
3. **Workflow** — replaces the dead `rohith/publish-nuget` (node12) + `actions/create-release@latest` with the first-party `dotnet` + `gh` publish flow (matching v6/v7), with v5's `net6.0/7.0/8.0` runtimes, so 5.1.0 can actually publish on current runners.

## Versioning

`5.0.0` → **`5.1.0`** (fluent is a new feature → minor). Note: the added type-name validation slightly *tightens* input handling (wrong-type global ids on `[ID("Type")]` now rejected) — intentional, and aligned with HC's own behaviour.

## Tests

All **27** pass on **net6.0 / net7.0 / net8.0**. Mirrors v7's tests: un-skipped fluent test (`PolyId_On_Objects_FluentStyle`), validation unit tests, and integration tests (reject wrong-type global id; accept raw + matching-type). Snapshots are HC14-specific (regenerated on this branch).

> Merging to `v5/main` will publish **5.1.0** to NuGet and create a `v5.1.0` GitHub release (via the new workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)